### PR TITLE
Tiny fixes, made project editable on mac OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ packages/
 *.Designer.cs
 *.orig
 *.rej
+
+#rider user-local files (according to https://intellij-support.jetbrains.com/hc/en-us/articles/206544839-How-to-manage-projects-under-Version-Control-Systems)
+**/.idea/workspace.xml
+**/.idea/tasks.xml

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ packages/
 *.nupkg
 *.designer.cs
 *.Designer.cs
-.idea/
+*.orig
+*.rej

--- a/.idea/.idea.Simple1C/.idea/.name
+++ b/.idea/.idea.Simple1C/.idea/.name
@@ -1,0 +1,1 @@
+Simple1C

--- a/.idea/.idea.Simple1C/.idea/modules.xml
+++ b/.idea/.idea.Simple1C/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/riderModule.iml" filepath="$PROJECT_DIR$/riderModule.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/.idea.Simple1C/.idea/vcs.xml
+++ b/.idea/.idea.Simple1C/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
+  </component>
+</project>

--- a/.idea/.idea.Simple1C/riderModule.iml
+++ b/.idea/.idea.Simple1C/riderModule.iml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="RIDER_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$/../..">
+      <sourceFolder url="file://$MODULE_DIR$/../../Generator" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../../Simple1C" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/../../Tests" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/../../Generator/obj" />
+      <excludeFolder url="file://$MODULE_DIR$/../../Simple1C/obj" />
+      <excludeFolder url="file://$MODULE_DIR$/../../Tests/obj" />
+      <excludeFolder url="file://$MODULE_DIR$/../../bin" />
+      <excludeFolder url="file://$MODULE_DIR$/../../bin.tests" />
+      <excludeFolder url="file://$MODULE_DIR$/../../packages" />
+    </content>
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/Simple1C/Impl/Sql/SqlAccess/Parsing/QueryGrammar.cs
+++ b/Simple1C/Impl/Sql/SqlAccess/Parsing/QueryGrammar.cs
@@ -30,10 +30,9 @@ namespace Simple1C.Impl.Sql.SqlAccess.Parsing
             : base(false)
         {
             LanguageFlags = LanguageFlags.CreateAst;
-            var comment = new CommentTerminal("comment", "/*", "*/");
-            var lineComment = new CommentTerminal("line_comment", "--", "\n", "\r\n");
-            NonGrammarTerminals.Add(comment);
-            NonGrammarTerminals.Add(lineComment);
+            NonGrammarTerminals.Add(new CommentTerminal("sql_style_comment", "/*", "*/"));
+            NonGrammarTerminals.Add(new CommentTerminal("sql_style_line_comment", "--", "\n", "\r\n"));
+            NonGrammarTerminals.Add(new CommentTerminal("1c_commene", "//", "\n", "\r\n"));
 
             not = Transient("not", ToTerm("NOT") | "НЕ");
             by = NonTerminal("by", ToTerm("by") | "ПО", TermFlags.NoAstNode);
@@ -102,10 +101,8 @@ namespace Simple1C.Impl.Sql.SqlAccess.Parsing
             MarkPunctuation(asOpt);
             AddOperatorReportGroup("operator");
             AddToNoReportGroup("as", "КАК");
-
             Root = root;
         }
-
 
         private static SelectFieldExpression ToSelectFieldExpression(ParseTreeNode n)
         {

--- a/Simple1C/Impl/Sql/SqlAccess/Parsing/QueryGrammar.cs
+++ b/Simple1C/Impl/Sql/SqlAccess/Parsing/QueryGrammar.cs
@@ -32,7 +32,7 @@ namespace Simple1C.Impl.Sql.SqlAccess.Parsing
             LanguageFlags = LanguageFlags.CreateAst;
             NonGrammarTerminals.Add(new CommentTerminal("sql_style_comment", "/*", "*/"));
             NonGrammarTerminals.Add(new CommentTerminal("sql_style_line_comment", "--", "\n", "\r\n"));
-            NonGrammarTerminals.Add(new CommentTerminal("1c_commene", "//", "\n", "\r\n"));
+            NonGrammarTerminals.Add(new CommentTerminal("1c_comment", "//", "\n", "\r\n"));
 
             not = Transient("not", ToTerm("NOT") | "НЕ");
             by = NonTerminal("by", ToTerm("by") | "ПО", TermFlags.NoAstNode);
@@ -58,7 +58,8 @@ namespace Simple1C.Impl.Sql.SqlAccess.Parsing
 
             var groupClauseOpt = GroupBy(expression);
             var orderClauseOpt = OrderBy(expression);
-            var havingClauseOpt = NonTerminal("havingClauseOpt", Empty | ToTerm("having") + expression,
+            var havingKeyword = Transient("havingKeyword", ToTerm("HAVING") | "ИМЕЮЩИЕ");
+            var havingClauseOpt = NonTerminal("havingClauseOpt", Empty | havingKeyword + expression,
                 node => node.ChildNodes.Count == 0 ? null : node.ChildNodes[1].AstNode);
             var columnItemList = NonTerminal("columnItemList", null);
 

--- a/Simple1C/Simple1C.csproj
+++ b/Simple1C/Simple1C.csproj
@@ -276,11 +276,16 @@
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>-->
+
   <Target Name="AfterBuild">
     <CreateItem Include="@(ReferencePath)" Condition="'%(CopyLocal)'=='true'">
       <Output TaskParameter="Include" ItemName="IlmergeAssemblies" />
     </CreateItem>
-    <Exec Command="&quot;..\packages\ilmerge.2.14.1208\tools\ILMerge.exe&quot; /internalize /out:@(MainAssembly) &quot;@(IntermediateAssembly)&quot; @(IlmergeAssemblies->'&quot;%(FullPath)&quot;', ' ')" />
+    <PropertyGroup>
+      <ILRepackCommand>"..\packages\ILRepack.2.0.11\tools\ILRepack.exe" /internalize /out:$(OutputPath)\$(AssemblyName).dll "@(IntermediateAssembly)" @(IlmergeAssemblies->'"%(FullPath)"', ' ')</ILRepackCommand>
+    </PropertyGroup>
+    <Exec Condition = "'$(OS)' = 'Unix'" Command="mono $(ILRepackCommand)"/>
+    <Exec Condition = "'$(OS)' != 'Unix'" Command="$(ILRepackCommand)"/>
     <Delete Files="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename)%(Extension)')" />
   </Target>
 </Project>

--- a/Simple1C/packages.config
+++ b/Simple1C/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ILMerge" version="2.14.1208" targetFramework="net45" />
+  <package id="ILRepack" version="2.0.11" targetFramework="net45" />
   <package id="Irony" version="0.9.1" targetFramework="net45" />
   <package id="Npgsql" version="3.1.7" targetFramework="net45" />
   <package id="Remotion.Linq" version="2.0.2" targetFramework="net45" />

--- a/Tests/Sql/ParserTest.cs
+++ b/Tests/Sql/ParserTest.cs
@@ -47,8 +47,9 @@ namespace Simple1C.Tests.Sql
         [Test]
         public void IgnoreComments()
         {
-            var selectClause = ParseSelect("select a/*,b*/ from testTable --where b > 10");
+            var selectClause = ParseSelect("select a/*,b*/ from testTable --where b > 10\r\n //group by a");
             Assert.That(selectClause.WhereExpression, Is.Null);
+            Assert.That(selectClause.GroupBy, Is.Null);
             Assert.That(selectClause.Fields.Count, Is.EqualTo(1));
             var columnReference = selectClause.Fields[0].Expression as ColumnReferenceExpression;
             Assert.IsNotNull(columnReference);

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -31,9 +31,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Remotion.Linq">
-      <HintPath>..\packages\Remotion.Linq.2.0.2\lib\net45\Remotion.Linq.dll</HintPath>
-    </Reference>
     <Reference Include="Metadata1C, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Assemblies\Metadata1C.dll</HintPath>


### PR DESCRIPTION
Немного фиксов из моей ветки с экспериментами которые вроде можно было бы влить в мастер. Не думаю, что это сильно кому-то надо, но вроде не повредит, а мне меньше возни если буду мерджить ваш мастер=)

Два микро-фикса в грамматике
+
Поборолся за то чтобы проект можно было редактировать на mac os:
* Добавил файлы Rider-а. Игнорить папку .idea целиком неправильно потому что в ней оседают в том числе командные настройки инспекций и код стайла, интеграции с гитом, итд. 
Если настроите, например, коннекшн к базе в Databases, он осядет в отдельном файлике - решайте, надо вам это или нет и игнорьте/не игнорьте его отдельно. 
Саппорт Идеи считает, что коммитить проект в гит надо так: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839-How-to-manage-projects-under-Version-Control-Systems

* Поборолся за билд на mono. Заюзал ILRepack вместо ILMerge. 
версия 2.0.12 сломана, но, надеюсь что последующие будут работать после того как чуваки вольют мой фикс:  https://github.com/gluck/il-repack/pull/176
В остальном ILRepack выглядит нормально, вроде работает. api тот же.